### PR TITLE
context redis 支持数组value

### DIFF
--- a/src/Context/Redis.php
+++ b/src/Context/Redis.php
@@ -47,7 +47,14 @@ class Redis extends \Owl\Context
     public function get($key = null)
     {
         if ($key === null) {
-            return $this->data;
+            return array_map(function ($item) {
+                $array_value = json_decode($item, true);
+                if (0 != json_last_error()) {
+                    return $item;
+                }
+
+                return $array_value;
+            }, $this->data);
         }
 
         $value = isset($this->data[$key]) ? $this->data[$key] : null;

--- a/src/Context/Redis.php
+++ b/src/Context/Redis.php
@@ -40,7 +40,7 @@ class Redis extends \Owl\Context
             return true;
         }
 
-        $this->data[$key] = $val;
+        $this->data[$key] = is_array($val) ? json_encode($val) : $val;
         $this->dirty = true;
     }
 
@@ -50,7 +50,13 @@ class Redis extends \Owl\Context
             return $this->data;
         }
 
-        return isset($this->data[$key]) ? $this->data[$key] : null;
+        $value = isset($this->data[$key]) ? $this->data[$key] : null;
+        $array_value = json_decode($value, true);
+        if (0 != json_last_error()) {
+            return $value;
+        }
+
+        return $array_value;
     }
 
     public function has($key)


### PR DESCRIPTION
在每次获取数据的时候,都使用json_decode()  去操作一次, 如果操作没有报错, 那么就返回decode 后的结果. 如果遇到错误, 就使用原始值. 

写完之后, 突然感觉这样做的意义又不是特别大了. ....